### PR TITLE
allows to open the most common extensions for markdown

### DIFF
--- a/src/notesProvider.ts
+++ b/src/notesProvider.ts
@@ -64,7 +64,7 @@ export class NotesProvider implements vscode.TreeDataProvider<Note> {
 			};
 			// get list of markdown files in notes location and save them in a list called listOfNotes
 			// this is markdown focused so markdown is hard coded
-			const notes = gl.sync(`*.md`, { cwd: notesLocation, nodir: true, nocase: true }).map(listOfNotes);
+			const notes = gl.sync(`*.{md,markdown,txt}`, { cwd: notesLocation, nodir: true, nocase: true }).map(listOfNotes);
 			// return the list of notes
 			return notes;
 		}


### PR DESCRIPTION
This "pull request" allows to open the most common extensions for Markdown files.

If the files contain the following extensions:
- .md
- .markdown"
- .txt
the application shows them in the list (not only ".md" extension).

This fix/feature is important because it makes it possible to open files that already exist in the directory.

Furthermore, we don't always want to write notes in Markdown format: sometimes we just want to write a plain text file (.txt). 😊