### PR TITLE
Fix: Only show welcome message when notes location is not configured

### DIFF
--- a/package.json
+++ b/package.json
@@ -218,7 +218,8 @@
 		"viewsWelcome": [
 			{
 				"view": "notes",
-				"contents": "To get started, you need to select a location to store your notes.\n[Select Location](command:Notes.setupNotes)"
+				"contents": "To get started, you need to select a location to store your notes.\n[Select Location](command:Notes.setupNotes)",
+				"when": "config.notes.notesLocation == ''"
 			}
 		]
 	},


### PR DESCRIPTION
**Summary:**
This pull request refines the welcome experience in the Notes view by conditionally displaying the "Select Location" prompt. Previously, the prompt remained visible even after a notes location was configured, making it harder for users to notice the available action buttons at the top.

**Changes:**

- The welcome message in the notes view now only appears when config.notes.notesLocation is unset or empty.
- Once a notes location is configured, the prompt is hidden, making the action buttons more discoverable and improving overall usability.

**Related issues:**

- #71 
- #69